### PR TITLE
[#12] Setting default config for pushing logs to Kafka flag

### DIFF
--- a/gimel-dataapi/gimel-logger/src/main/scala/com/paypal/gimel/logger/Logger.scala
+++ b/gimel-dataapi/gimel-logger/src/main/scala/com/paypal/gimel/logger/Logger.scala
@@ -75,8 +75,17 @@ class Logger(config: Any) extends Serializable {
   private val logModes = Map(4 -> "INFO", 3 -> "DEBUG", 2 -> "WARN", 1 -> "ERROR")
   @volatile private var logMode = 4
   val logger: JSONSystemLogger = JSONSystemLogger.getInstance(getClass)
-
+  private var logAudit = false
   var consolePrintEnabled = false
+
+  /**
+    * Set Log Level Push to Kafka
+    *
+    * @param customLogAudit Boolean property to push logs to kafka
+    */
+  def setLogAudit(customLogAudit: Boolean = true): Unit = {
+    logAudit = customLogAudit
+  }
 
   /**
     * Set Log Level
@@ -234,9 +243,12 @@ class Logger(config: Any) extends Serializable {
       "additionalProps" -> additionalProps
     )
 
-    this.info("Auditing Information being posted to Gimel Audit Log...")
-    this.info(accessAuditInfo)
-    logger.info(accessAuditInfo.asJava)
+
+    if (logAudit) {
+      this.info("Auditing Information being posted to Gimel Audit Log...")
+      this.info(accessAuditInfo)
+      logger.info(accessAuditInfo.asJava)
+    }
     accessAuditInfo
   }
 
@@ -294,9 +306,11 @@ class Logger(config: Any) extends Serializable {
       "additionalProps" -> additionalProps
     )
 
-    this.info("Auditing Information being posted to Gimel Audit Log...")
-    this.info(accessAuditInfo)
-    logger.info(accessAuditInfo.asJava)
+    if (logAudit) {
+      this.info("Auditing Information being posted to Gimel Audit Log...")
+      this.info(accessAuditInfo)
+      logger.info(accessAuditInfo.asJava)
+    }
 
     this.logMethodAccess(yarnAppId
       , yarnAppName


### PR DESCRIPTION
@Dee-Pac 

Please take a look and let me know if you have any questions. 

This Pull request fixes a bug in the code where Auditing is turned on by default & hence the logger makes an attempt to push the logs to kafka & this results in failure because everyone trying to use Gimel then requires a Kafka Cluster for logging audit logs (who accessed which dataset when & where)

However this fix does not address the fact that when we want to turn on auditing data - it is not possible via a simple `set` option. 