### PR TITLE
[#39] [Gimel Properties] Add a fix to load pcatalog.properties file correctly

### DIFF
--- a/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/conf/GimelConstants.scala
+++ b/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/conf/GimelConstants.scala
@@ -27,7 +27,7 @@ object GimelConstants {
   val RESOLVED_HIVE_TABLE: String = "resolvedHiveTable"
   val SPARK_APP_NAME: String = "spark.app.name"
   val GIMEL_PROPERTIES_FILE_KEY: String = "gimel.property.file"
-  val GIMEL_PROPERTIES_FILE_NAME = "./pcatalog.properties"
+  val GIMEL_PROPERTIES_FILE_NAME = "/pcatalog.properties"
   val DATASET_PROPS: String = "dataSetProperties"
   val APP_TAG: String = "appTag"
   val DATASET: String = "dataSet"


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template
- [x] This PR includes the URL to the GitHub Issue 

### What is the purpose of this pull request?
The purpose of the pull request is to fix the bug related to the load of default pcatalog properties. It addresses ISSUE-39 (https://github.com/paypal/gimel/issues/39)

### How was this change validated?
The changes were tested in Spark shell


### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

