### PR TITLE
[#89] [BugFix] Use absolute path instead of relative path in build script

### DIFF
--- a/build/install_dependencies
+++ b/build/install_dependencies
@@ -16,7 +16,8 @@
 # limitations under the License.
 
 
-this_dir=`dirname build/install_dependencies`
+this_script=`pwd`/$BASH_SOURCE
+this_dir=`dirname $this_script`
 # Source reusable functions
 source ${this_dir}/gimel_functions
 
@@ -24,13 +25,13 @@ source ${this_dir}/gimel_functions
 
 write_log "Begin    | Script | $0"
 
-mvn install:install-file -DgroupId=qubole-hive-JDBC -DartifactId=qubole-hive-JDBC -Dversion=0.0.7 -Dpackaging=jar -Dfile=lib/qubole-hive-JDBC.jar 1>>/dev/null 2>&1
+mvn install:install-file -DgroupId=qubole-hive-JDBC -DartifactId=qubole-hive-JDBC -Dversion=0.0.7 -Dpackaging=jar -Dfile=${this_dir}/../lib/qubole-hive-JDBC.jar 1>>/dev/null 2>&1
 check_error $? "install qubole-hive-JDBC"
 
-mvn install:install-file -DgroupId=com.hortonworks -DartifactId=shc-core -Dversion=1.1.2-2.2-s_2.11 -Dpackaging=jar -Dfile=lib/shc-core.jar 1>>/dev/null 2>&1
+mvn install:install-file -DgroupId=com.hortonworks -DartifactId=shc-core -Dversion=1.1.2-2.2-s_2.11 -Dpackaging=jar -Dfile=${this_dir}/../lib/shc-core.jar 1>>/dev/null 2>&1
 check_error $? "install shc-core"
 
-mvn install:install-file -DgroupId=com.osscube -DartifactId=aerospike-spark -Dversion=0.3-SNAPSHOT -Dpackaging=jar -Dfile=lib/aerospike-spark.jar 1>>/dev/null 2>&1
+mvn install:install-file -DgroupId=com.osscube -DartifactId=aerospike-spark -Dversion=0.3-SNAPSHOT -Dpackaging=jar -Dfile=${this_dir}/../lib/aerospike-spark.jar 1>>/dev/null 2>&1
 check_error $? "install aerospike-spark"
 
 write_log "Complete | Script | $0"

--- a/docs/getting-started/build-gimel.md
+++ b/docs/getting-started/build-gimel.md
@@ -15,6 +15,20 @@ OR
 git clone https://github.com/paypal/gimel.git
 cd gimel
 ```
+## Before building with maven
+
+This Project depends on below project as dependency.
+
+https://github.com/sasha-polev/aerospar
+https://github.com/qubole/Hive-JDBC-Storage-Handler
+https://github.com/hortonworks-spark/shc
+
+For convenience, we've included binaries for all above projects.
+Please run following command to install all dependencies before building with maven.
+
+```bash
+$sh build/install_dependencies
+```
 
 ## Maven Profiles
 


### PR DESCRIPTION
### GitHub Issue
Fixes #89 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [x] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
This fix enables to run install_dependencies script from anywhere.

### How was this change validated?
run a couple of tests by running following commands
```bash
~/>sh gimel/build/install_dependencies
~/gimel/build>sh install_dependencies
```
All succeded.

