### PR TITLE
[#83][Enhancement] [Kafka API] Enable feature to choose specific partition & offsets via API 

### DIFF
--- a/docs/gimel-connectors/kafka.md
+++ b/docs/gimel-connectors/kafka.md
@@ -91,7 +91,7 @@
 | gimel.kafka.throttle.streaming.isParallel | N | <br>Use in Streaming Mode to parallelize the steps where deserialization happens<br>this feature is recommended if preserving ordering is not a necessity in the sink (like HDFS)<br>Once messages are fetched from kafka, with this flag turned ON, messages can be repartition across executors to process data in parallel via below listed properties<br> | false | true |
 | gimel.kafka.throttle.streaming.maxRatePerPartition | N | Max Records to Process per partition | 1000 | 3600 |
 | gimel.kafka.throttle.stream.parallelism.factor | N | The number of executors / repartitions to create while deserializing. | 10 | 10 |
-
+| gimel.kafka.custom.offset.range | N | The Custom Offset range and partition to read from | [{\"topic\": \"gimel.demo.flights.json\",\"offsetRange\": [{\"partition\": 0,\"from\": 1200000,\"to\": 1200001}]}] | |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaClientConfiguration.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaClientConfiguration.scala
@@ -91,6 +91,9 @@ class KafkaClientConfiguration(val props: Map[String, Any]) {
   val kafkaZKTimeOutMilliSec: String = tableProps.getOrElse(KafkaConfigs.zookeeperConnectionTimeoutKey, 10000.toString)
   val kafkaAutoOffsetReset: String = tableProps.getOrElse(KafkaConfigs.offsetResetKey, "smallest")
   val kafkaTopic: String = tableProps.getOrElse(KafkaConfigs.whiteListTopicsKey, "")
+  val kafkaCustomOffsetRange: String = tableProps.getOrElse(KafkaConfigs.customOffsetRange, "")
+  val consumerModeBatch: String = tableProps.getOrElse(KafkaConstants.gimelAuditRunTypeBatch, "BATCH")
+  val consumerModeStream: String = tableProps.getOrElse(KafkaConstants.gimelAuditRunTypeStream, "STREAM")
 
   // Kafka Serde
   val kafkaKeySerializer: String = tableProps.getOrElse(KafkaConfigs.serializerKey, KafkaConfigs.kafkaStringSerializer)

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaConfigs.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaConfigs.scala
@@ -72,6 +72,7 @@ object KafkaConfigs {
   val streamFailureWindowFactorKey: String = "gimel.kafka.fail.stream.window.factor"
   val kafkaConsumerReadCheckpointKey: String = "gimel.kafka.reader.checkpoint.save"
   val kafkaConsumerClearCheckpointKey: String = "gimel.kafka.reader.checkpoint.clear"
+  val customOffsetRange: String = "gimel.kafka.custom.offset.range"
   // default packages used in Kafka read/write API
   val paypalMetricsReporterValue: String = "com.paypal.kafka.reporters.KafkaClientMetricsReporter"
   val paypalInterceptorClassName: String = "com.paypal.kafka.clients.interceptors.MonitoringConsumerInterceptor"

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaJsonProtocol.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/conf/KafkaJsonProtocol.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 PayPal Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.paypal.gimel.kafka.conf
+
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+
+import com.paypal.gimel.kafka.utilities.{OffsetProperties, OffsetRangeProperties}
+
+
+object KafkaJsonProtocol extends DefaultJsonProtocol {
+  implicit val offsetRangePropertiesFormat: RootJsonFormat[OffsetRangeProperties] = jsonFormat3(OffsetRangeProperties)
+  implicit val offsetPropertiesFormat: RootJsonFormat[OffsetProperties] = jsonFormat2(OffsetProperties)
+}

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/reader/KafkaBatchConsumer.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/reader/KafkaBatchConsumer.scala
@@ -38,6 +38,7 @@ object KafkaBatchConsumer {
 
   val logger = com.paypal.gimel.logger.Logger()
 
+
   /**
     * Connects to Kafka, Deserializes data from Kafka, Attempts to Convert Avro to a DataFrame
     *
@@ -55,21 +56,29 @@ object KafkaBatchConsumer {
 
     val kafkaParams: Map[String, String] = conf.kafkaConsumerProps
     try {
-      val lastCheckPoint: Option[Array[OffsetRange]] = getLastCheckPointFromZK(conf.zkHostAndPort, conf.zkCheckPoint)
-      val availableOffsetRange: Array[OffsetRange] = BrokersAndTopic(conf.kafkaHostsAndPort, conf.kafkaTopic).toKafkaOffsetsPerPartition
-      val newOffsetRangesForReader = getNewOffsetRangeForReader(lastCheckPoint, availableOffsetRange, conf.fetchRowsOnFirstRun)
-      logger.info("Offset Ranges From Difference -->")
-      newOffsetRangesForReader.foreach(x => logger.info(x.toString))
-      val toFetchFromKafkaWithThresholds: Array[OffsetRange] = newOffsetRangesForReader.applyThresholdPerPartition(conf.maxRecsPerPartition.toLong) // Restrict Offset Ranges By Applying Threshold Per Partition
-      logger.info("Offset Ranges After applying Threshold Per Partition -->")
-      toFetchFromKafkaWithThresholds.foreach(x => logger.info(x.toString))
-      val parallelizedRanges: Array[OffsetRange] = toFetchFromKafkaWithThresholds.parallelizeOffsetRanges(conf.parallelsPerPartition, conf.minRowsPerParallel)
+      val finalOffsetRangesForReader: Array[OffsetRange] =
+        if (conf.kafkaCustomOffsetRange.isEmpty()) {
+          logger.info(s"""No custom offset information was given by the user""")
+          val lastCheckPoint: Option[Array[OffsetRange]] = getLastCheckPointFromZK(conf.zkHostAndPort, conf.zkCheckPoint)
+          val availableOffsetRange: Array[OffsetRange] = BrokersAndTopic(conf.kafkaHostsAndPort, conf.kafkaTopic).toKafkaOffsetsPerPartition
+          val newOffsetRangesForReader = getNewOffsetRangeForReader(lastCheckPoint, availableOffsetRange, conf.fetchRowsOnFirstRun)
+          logger.info("Offset Ranges From Difference -->")
+          newOffsetRangesForReader.foreach(x => logger.info(x.toString))
+          newOffsetRangesForReader.applyThresholdPerPartition(conf.maxRecsPerPartition.toLong) // Restrict Offset Ranges By Applying Threshold Per Partition
+        }
+        else {
+          logger.info(s"""Custom offset information was given by the user""")
+          getCustomOffsetRangeForReader(conf.kafkaCustomOffsetRange, conf.consumerModeBatch)
+        }
+      logger.info("Offset Ranges After applying Threshold Per Partition/Custom Offsets -->")
+      finalOffsetRangesForReader.foreach(x => logger.info(x.toString))
+      val parallelizedRanges: Array[OffsetRange] = finalOffsetRangesForReader.parallelizeOffsetRanges(conf.parallelsPerPartition, conf.minRowsPerParallel)
       logger.info("Final Array of OffsetRanges to Fetch from Kafka --> ")
       parallelizedRanges.foreach(range => logger.info(range))
       if (parallelizedRanges.isEmpty) throw new KafkaUtilitiesException("There is an issue ! No Offset Range From Kafka ... Is the topic having any message at all ?")
       val sqlContext = sparkSession.sqlContext
       val data: DataFrame = getAsDFFromKafka(sqlContext, conf, parallelizedRanges)
-      (data, toFetchFromKafkaWithThresholds)
+      (data, finalOffsetRangesForReader)
     } catch {
       case ex: Throwable =>
         ex.printStackTrace()


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #83 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [] This pull request updates the documentation
- [] This pull request changes library dependencies
- [ ] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->
This PR closes Issue #83 

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->
Was tested in standalone - spark shell with kafka connector

Commands relevant in spark shell:
```scala
import org.apache.spark.sql.{DataFrame, SQLContext};
import org.apache.spark.sql.hive.HiveContext;
import com.paypal.gimel.sql.GimelQueryProcessor
val gsql = GimelQueryProcessor.executeBatch(_:String,spark)
gsql("set gimel.catalog.provider=USER")
val datasetKafkaPropsJson = """{
	"datasetType": "KAFKA",
	"fields": [],
	"partitionFields": [],
	"props": {
		"gimel.storage.type": "kafka",
		"gimel.logging.level": "INFO",
		"gimel.kafka.message.value.type": "json",
		"gimel.kafka.whitelist.topics": "gimel.demo.flights.json",
		"bootstrap.servers": "kafka:9092",
		"gimel.kafka.checkpoint.zookeeper.host": "zookeeper:2181",
		"gimel.kafka.checkpoint.zookeeper.path": "/pcatalog/kafka_consumer/checkpoint/flights",
		"gimel.kafka.zookeeper.connection.timeout.ms": "10000",
		"gimel.kafka.throttle.batch.maxRecordsPerPartition": "10000000",
		"gimel.kafka.throttle.batch.fetchRowsOnFirstRun":"10000000", 
		"key.serializer": "org.apache.kafka.common.serialization.StringSerializer",
		"value.serializer": "org.apache.kafka.common.serialization.StringSerializer",
		"key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
		"value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
		"datasetName": "pcatalog.flights_kafka_json",
				"gimel.kafka.custom.offset.range": "[{\"topic\": \"gimel.demo.flights.json\",\"offsetRange\": [{\"partition\": 0,\"from\": 3021812,\"to\": 3021815}]}]"
	}
}"""
val kafkaOptions = Map("pcatalog.flights_kafka_json.dataSetProperties"->datasetKafkaPropsJson)
import com.paypal.gimel._
val dataSet = DataSet(spark)
val df = dataSet.read("pcatalog.flights_kafka_json",kafkaOptions)
```

### Commit Guidelines
- [ ] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

