### PR TITLE
[#110] [Enhancement] [Gimel-Kafka] Feature to read from Multiple Topics with same schema

### DIFF
--- a/docs/gimel-connectors/kafka.md
+++ b/docs/gimel-connectors/kafka.md
@@ -69,7 +69,7 @@
 | Property | Mandatory? | Description | Example | Default |
 |----------|------------|-------------|------------|-------------------|
 | bootstrap.servers | Y | the broker list for kafka | host1:9092,host2:9092 | |
-| gimel.kafka.kafka.whitelist.topics | Y | the topic name in kafka | flights | |
+| gimel.kafka.kafka.whitelist.topics | Y | the topic names in kafka separated by comma | flights,flights1 | |
 | key.serializer | Y | the kafka key serializer | | org.apache.kafka.common.serialization.StringSerializer |
 | value.serializer | Y | the kafka message serializer | org.apache.kafka.common.serialization.StringSerializer | org.apache.kafka.common.serialization.ByteArraySerializer |
 | key.deserializer | Y | the kafka key DeSerializer | | org.apache.kafka.common.serialization.StringDeserializer |

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/DataSet.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/DataSet.scala
@@ -30,7 +30,7 @@ import com.paypal.gimel.datasetfactory.GimelDataSet
 import com.paypal.gimel.kafka.conf.KafkaClientConfiguration
 import com.paypal.gimel.kafka.reader.KafkaBatchConsumer
 import com.paypal.gimel.kafka.utilities.ImplicitZKCheckPointers._
-import com.paypal.gimel.kafka.utilities.ZooKeeperHostAndNode
+import com.paypal.gimel.kafka.utilities.ZooKeeperHostAndNodes
 import com.paypal.gimel.kafka.writer.KafkaBatchProducer
 import com.paypal.gimel.logger.Logger
 
@@ -58,9 +58,9 @@ class DataSet(sparkSession: SparkSession) extends GimelDataSet(sparkSession: Spa
     if (alreadyCheckPointed) {
       logger.warning("Already Check-Pointed, Consume Again to Checkpoint !")
     } else {
-      val zkNode = conf.zkCheckPoint
+      val zkNode = conf.zkCheckPoints
       val zkHost = conf.zkHostAndPort
-      val zk = ZooKeeperHostAndNode(zkHost, zkNode)
+      val zk = ZooKeeperHostAndNodes(zkHost, zkNode)
       (zk, readTillOffsetRange.get).saveZkCheckPoint
       alreadyCheckPointed = true
       logger.info(s"Check-Point --> ${readTillOffsetRange.get.mkString("|")} | Success @ -> ${zk} ")
@@ -71,9 +71,9 @@ class DataSet(sparkSession: SparkSession) extends GimelDataSet(sparkSession: Spa
     * Completely Clear the CheckPointed Offsets, leading to Read from Earliest offsets from Kafka
     */
   def clearCheckPoint(): Unit = {
-    val zkNode = conf.zkCheckPoint
+    val zkNode = conf.zkCheckPoints
     val zkHost = conf.zkHostAndPort
-    val zk = ZooKeeperHostAndNode(zkHost, zkNode)
+    val zk = ZooKeeperHostAndNodes(zkHost, zkNode)
     zk.deleteZkCheckPoint()
   }
 

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/reader/KafkaBatchConsumer.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/reader/KafkaBatchConsumer.scala
@@ -59,8 +59,8 @@ object KafkaBatchConsumer {
       val finalOffsetRangesForReader: Array[OffsetRange] =
         if (conf.kafkaCustomOffsetRange.isEmpty()) {
           logger.info(s"""No custom offset information was given by the user""")
-          val lastCheckPoint: Option[Array[OffsetRange]] = getLastCheckPointFromZK(conf.zkHostAndPort, conf.zkCheckPoint)
-          val availableOffsetRange: Array[OffsetRange] = BrokersAndTopic(conf.kafkaHostsAndPort, conf.kafkaTopic).toKafkaOffsetsPerPartition
+          val lastCheckPoint: Option[Array[OffsetRange]] = getLastCheckPointFromZK(conf.zkHostAndPort, conf.zkCheckPoints)
+          val availableOffsetRange: Array[OffsetRange] = BrokersAndTopic(conf.kafkaHostsAndPort, conf.kafkaTopics).toKafkaOffsetsPerPartition
           val newOffsetRangesForReader = getNewOffsetRangeForReader(lastCheckPoint, availableOffsetRange, conf.fetchRowsOnFirstRun)
           logger.info("Offset Ranges From Difference -->")
           newOffsetRangesForReader.foreach(x => logger.info(x.toString))

--- a/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/writer/KafkaBatchProducer.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-kafka-0.10/src/main/scala/com/paypal/gimel/kafka/writer/KafkaBatchProducer.scala
@@ -54,7 +54,7 @@ object KafkaBatchProducer {
     logger.info(" @Begin --> " + MethodName)
 
     val kafkaProps: Properties = conf.kafkaProducerProps
-    val kafkaTopic = conf.kafkaTopic
+    val kafkaTopic = conf.kafkaTopics
     logger.info(s"Kafka Props for Producer -> ${kafkaProps.asScala.mkString("\n")}")
     logger.info("Begin Publishing to Kafka....")
     try {
@@ -109,7 +109,7 @@ object KafkaBatchProducer {
       case (_, "org.apache.kafka.common.serialization.ByteArraySerializer") => {
         val kafkaProps: Properties = conf.kafkaProducerProps
         val avroSchemaString = conf.avroSchemaString
-        val kafkaTopic = conf.kafkaTopic
+        val kafkaTopic = conf.kafkaTopics
         logger.debug(s"Kafka Props for Producer -> ${kafkaProps.asScala.mkString("\n")}")
         logger.debug(s"avro Schema --> ${avroSchemaString}")
         logger.debug(s"dataframe Schema --> ${dataFrame.schema}")


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #110 

### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [x] This pull request updates the documentation
- [x] This pull request changes library dependencies
- [ ] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
<!-- Please fill in changes proposed in this pull request. -->
This pull request adds the feature to read from multiple kafka topics and return a single dataframe containing all the messages.
<!-- Example: This Pull Request upgrades codebase to spark 3.0.0  -->

### How was this change validated?
<!-- Please add the Command Used, Results Snippet, details on how reviewer/committer can simulate issue & verify the change -->
Tested in standalone spark shell
```
### Create the kafka topics names user, user1
"docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic user"
"docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic user1"

### Start your spark shell
docker exec -it spark-master bash -c "export USER=an;export SPARK_HOME=/spark/;export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin; \
/spark/bin/spark-shell --verbose --master local --num-executors 1 --conf spark.executor.cores=1 --conf spark.driver.cores=1 --jars /root/gimel-sql-1.2.0-SNAPSHOT-uber.jar"

### Create the dataset pointing to user
gsql("""CREATE EXTERNAL TABLE pcatalog.user(
 id int,
 name string,
 rev bigint)
LOCATION 'hdfs://namenode:8020/tmp/user'
TBLPROPERTIES (
  'gimel.storage.type' = 'KAFKA',
  'bootstrap.servers'='kafka:9092',
  'gimel.kafka.whitelist.topics'='user',
  'gimel.kafka.checkpoint.zookeeper.host'='zookeeper:2181',
  'gimel.kafka.checkpoint.zookeeper.path'='/pcatalog/kafka_consumer/checkpoint/user',
  'key.serializer'='org.apache.kafka.common.serialization.StringSerializer',
  'value.serializer'='org.apache.kafka.common.serialization.ByteArraySerializer',
    'value.deserializer' = 'org.apache.kafka.common.serialization.ByteArrayDeserializer',
    'key.deserializer' = 'org.apache.kafka.common.serialization.StringDeserializer',
  'zookeeper.connection.timeout.ms'='10000',
  'auto.offset.reset'='earliest',
  'gimel.kafka.avro.schema.string'=' {
   "type" : "record",
   "namespace" : "pcatalog",
   "name" : "user",
   "fields" : [
         { "name" : "id" , "type" : "int" },
         { "name" : "name" , "type" : "string" },
      	 { "name" : "rev" , "type" : "int" }   ]}'
   )""")

### Populate the dataset named user
import org.apache.avro.generic.GenericRecord;
import com.paypal.gimel.logger.Logger;
import com.paypal.gimel.datastreamfactory.{StreamingResult, WrappedData};
import com.paypal.gimel._;
import org.apache.spark.rdd._
import org.apache.spark.streaming._
import org.apache.spark._
import org.apache.spark.sql._
   def stringed(n: Int) = s"""{"id": ${n}, "name": "MAC-${n}", "rev": ${n}}"""
   val texts: Seq[String] = (1 to 2).map { x => stringed(x) }.toSeq
   val rdd: RDD[String] = sc.parallelize(texts)
   val df: DataFrame = spark.read.json(rdd)
   val dataset = com.paypal.gimel.DataSet(spark)
   val datasetName = "pcatalog.user"
   dataset.write(datasetName,df)

### Make the dataset point to user1 topic
gsql("ALTER TABLE pcatalog.user SET TBLPROPERTIES('gimel.kafka.whitelist.topics' = 'user1') ")
###Populate this dataset as specified above
###Now make the dataset point to both user,user1 topics
gsql("ALTER TABLE pcatalog.user SET TBLPROPERTIES('gimel.kafka.whitelist.topics' = 'user,user1') ")

### Testing Batch Consumer
gsql("select * from pcatalog.user").collect.foreach(println)

### Testing Stream Consumer
import org.apache.avro.generic.GenericRecord;
import com.paypal.gimel.logger.Logger;
import com.paypal.gimel.datastreamfactory.{StreamingResult, WrappedData};
import com.paypal.gimel._;
import org.apache.spark.rdd._
import org.apache.spark.streaming._
import org.apache.spark._
import org.apache.spark.sql._
val batchInterval = 10
sc.setLogLevel("INFO")
val ssc = new StreamingContext(sc, Seconds(batchInterval.toInt))
val dataStream = DataStream(ssc)
val datasetName = "pcatalog.user"
val streamingResult: StreamingResult = dataStream.read(datasetName)
streamingResult.clearCheckPoint("clear")
//Helper for Clients
  streamingResult.dStream.foreachRDD { rdd =>
    val k: RDD[WrappedData] = rdd
    val count = rdd.count()
    if (count > 0) {
      /**
        * Mandatory | Get Offset for Current Window, so we can checkpoint at the end of this window's operation
        */
      streamingResult.getCurrentCheckPoint(rdd)
      /**
        * Begin | User's Usecases
        */
      //Sample UseCase | Display Count
      println("count is -->")
      println(count)
      //Sample UseCase | Get Avro Generic Record
      val rddAvro: RDD[GenericRecord] = streamingResult.convertBytesToAvro(rdd)
      rddAvro.map(x => x.toString)
      println("sample records from Avro-->")
      rddAvro.map(x => x.toString).take(10).foreach(x => println(x))
      /**
        * End | User's Usecases
        */
      /**
        * Mandatory | Save Current Window - CheckPoint
        */
      streamingResult.saveCurrentCheckPoint()
    }
  }
dataStream.streamingContext.start()
dataStream.streamingContext.stop(stopSparkContext = false)
```

<!-- Example: In addition to unit-tests, and integration-test, I ran X on the Y cluster and verified the Z output.-->

### Commit Guidelines
- [] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

