### PR TITLE
[#131] [UDC][SERVICES] Invoke UDC build from any directory instead of udc-serv and removing the user prompts

### DIFF
--- a/udc/udc-serv/build/udc
+++ b/udc/udc-serv/build/udc
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-this_dir=`dirname build/udc`
-source ${this_dir}/udc_functions
-
+export this_file=${0}
+echo $this_file
+export this_script_path="$( cd "$( dirname "$this_file" )" && pwd)"
+echo $this_script_path
+cd $this_script_path
+source ${this_script_path}/udc_functions
+cd ..
 write_log "Begin    | Script | $0"
 user_args=$@
 user_args_count=$#
@@ -11,7 +15,7 @@ write_log "User Arguments : ${user_args}"
 
 if [ $user_args_count -gt 0 ]; then
   resolved_args=${user_args_count}
-else 
+else
   write_log "User supplied arguments : None. Defaulting to argument : ${default_args}"
 fi
 

--- a/udc/udc-serv/quickstart/setup-udc-containers
+++ b/udc/udc-serv/quickstart/setup-udc-containers
@@ -30,41 +30,17 @@ run_cmd "docker rm ${udc_serv_container_name}" "ignore_errors"
 check_warning $? "docker rm ${udc_serv_container_name}"
 
 write_log "------------------------------------------------------------------------------"
-write_log "          Checking if udc metastore mysql image is installed already"
+write_log "          Installing the Metastore MySQL Image"
 write_log "------------------------------------------------------------------------------"
 
-if test ! -z "$(docker images -q ${mysql_image_name})"; then
-	write_log "Docker image for ${mysql_imager_name} already Exists"
-	get_option "Do you wish to pull the Docker Image ? "
-	if [ "${install_status}" = "Y" ]
-	then
-		run_cmd "docker pull ${mysql_image_name}"
-		check_error $? "docker pull ${mysql_image_name}"
-	else
-		write_log "Skipping installing MySQL Docker Image"	
-	fi
-else
-        run_cmd "docker pull ${mysql_image_name}"
-	check_error $? "docker pull ${mysql_image_name}"
-fi
+run_cmd "docker pull ${mysql_image_name}"
+check_error $? "docker pull ${mysql_image_name}"
 
 write_log "------------------------------------------------------------------------------"
-write_log "          Checking if udc services image is installed already"
+write_log "          Installing the UDC-SERVICES Image"
 write_log "------------------------------------------------------------------------------"
-if test ! -z "$(docker images -q ${udc_serv_image_name})"; then
-        write_log "Docker image for ${udc_serv_image_name} already Exists"
-        get_option "Do you wish to reinstall the docker image for services  ? "
-        if [ "${install_status}" = "Y" ]
-        then
-                run_cmd "docker build -f $UDC_HOME/Dockerfile -t ${udc_serv_image_name} ."
-                check_error $? "docker build -f ${UDC_HOME}/Dockerfile -t ${udc_serv_image_name} ."
-        else
-                write_log "Skipping installing UDC-SERVICES docker image"
-        fi
-else
-        run_cmd "docker build -f $UDC_HOME/Dockerfile -t ${udc_serv_image_name} ."
-        check_error $? "docker build -f $UDC_HOME/Dockerfile -t ${udc_serv_image_name} ."
-fi
+run_cmd "docker build -f $UDC_HOME/Dockerfile -t ${udc_serv_image_name} ."
+check_error $? "docker build -f $UDC_HOME/Dockerfile -t ${udc_serv_image_name} ."
 
 write_log "------------------------------------------------------------------------------"
 write_log "    Starting Docker Container for UDC-METASTORE and installing database"


### PR DESCRIPTION
### GitHub Issue
Fixes #131 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [] This pull request updates the documentation
- [] This pull request changes library dependencies
- [X] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

### What is the purpose of this pull request?
The purpose of the PR is to invoke the UDC build from any directory instead of udc-serv and removing the user prompts for fetching the docker image pertaining to `MySQL` and `UDC-SERVICES`

### How was this change validated?
The change was validated in local environment.

### Commit Guidelines
- [X] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

