### PR TITLE
[#182] Scan sample records for getting hbase schema

### DIFF
--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/DataSet.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/DataSet.scala
@@ -62,9 +62,9 @@ class DataSet(sparkSession: SparkSession) extends GimelDataSet(sparkSession: Spa
   override def read(dataset: String, dataSetProps: Map[String, Any]): DataFrame = {
     if (dataSetProps.isEmpty) throw new DataSetException("props cannot be empty !")
 
-    val hbaseOperation = dataSetProps.getOrElse(HbaseConfigs.hbaseOperation, HbaseConstants.scanOperation).toString
+    val hbaseOperation = dataSetProps.getOrElse(HbaseConfigs.hbaseOperation, HbaseConstants.SCAN_OPERATION).toString
     hbaseOperation match {
-      case HbaseConstants.getOperation =>
+      case HbaseConstants.GET_OPERATION =>
         logger.info("Reading through Java Get API.")
         hbaseLookUp.get(dataset, dataSetProps)
       case _ =>
@@ -91,9 +91,9 @@ class DataSet(sparkSession: SparkSession) extends GimelDataSet(sparkSession: Spa
     }
 
     val castedDataFrame = hbaseUtilities.castAllColsToString(dataFrame)
-    val hbaseOperation = dataSetProps.getOrElse(HbaseConfigs.hbaseOperation, HbaseConstants.scanOperation).toString
+    val hbaseOperation = dataSetProps.getOrElse(HbaseConfigs.hbaseOperation, HbaseConstants.SCAN_OPERATION).toString
     hbaseOperation match {
-      case HbaseConstants.putOperation =>
+      case HbaseConstants.PUT_OPERATION =>
         logger.info("Writing through Java Put API.")
         hbasePut.put(dataset, castedDataFrame, dataSetProps)
       case _ =>

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseClientConfiguration.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseClientConfiguration.scala
@@ -51,11 +51,9 @@ class HbaseClientConfiguration(val props: Map[String, Any]) {
   val clusterName = com.paypal.gimel.common.utilities.DataSetUtils.getYarnClusterName()
   val hbaseNameSpaceAndTable = GenericUtils.getValueFailIfEmpty(tableProps, HbaseConfigs.hbaseTableKey,
     "HBase table name not found. Please set the property " + HbaseConfigs.hbaseTableKey)
-  val hbaseTableColumnMapping = GenericUtils.getValueFailIfEmpty(tableProps, HbaseConfigs.hbaseColumnMappingKey,
-    s"""
-       | HBase column family to columns mapping not found. Please set the property ${HbaseConfigs.hbaseColumnMappingKey}.
-       | Example: cf1:col1,cf1:col2,cf2:col3
-       |""".stripMargin)
+  val hbaseTableColumnMapping = tableProps.getOrElse(HbaseConfigs.hbaseColumnMappingKey, "")
+  val maxSampleRecordsForSchema = GenericUtils.getValue(tableProps, HbaseConfigs.hbaseMaxRecordsForSchema, HbaseConstants.MAX_SAMPLE_RECORDS_FOR_SCHEMA).toInt
+  val maxColumnsForSchema = GenericUtils.getValue(tableProps, HbaseConfigs.hbaseMaxColumnsForSchema, HbaseConstants.MAX_COLUMNS_FOR_SCHEMA).toInt
   // If this property consists of namespace and tablename both separated by colon ":", take the table name by splitting this string
   val hbaseTableNamespaceSplit = hbaseNameSpaceAndTable.split(":")
   val hbaseTableName = if (hbaseTableNamespaceSplit.length > 1) {
@@ -63,7 +61,7 @@ class HbaseClientConfiguration(val props: Map[String, Any]) {
   } else {
     hbaseNameSpaceAndTable
   }
-  val hbaseNameSpace = tableProps.getOrElse(HbaseConfigs.hbaseNamespaceKey, HbaseConstants.hbaseDefaultNamespace)
+  val hbaseNameSpace = tableProps.getOrElse(HbaseConfigs.hbaseNamespaceKey, HbaseConstants.DEFAULT_NAMESPACE)
   // If ColumnFamily name needs to be appneded with Column Name in resultant Dataframe
   val hbaseColumnNamewithColumnFamilyAppended = tableProps.getOrElse(HbaseConfigs.hbaseColumnNamewithColumnFamilyAppended, "false").toString.toBoolean
   // HDFS path for hbase-site.xml
@@ -77,7 +75,7 @@ class HbaseClientConfiguration(val props: Map[String, Any]) {
   val getOption = tableProps.getOrElse(HbaseConfigs.hbaseFilter, "")
 
   // Getting Row Key from user otherwise from schema in UDC or hive table. If it is not present in schema also, set defaultValue
-  val hbaseRowKeys = tableProps.getOrElse(HbaseConfigs.hbaseRowKey, HbaseConstants.defaultRowKeyColumn).split(",")
+  val hbaseRowKeys = tableProps.getOrElse(HbaseConfigs.hbaseRowKey, HbaseConstants.DEFAULT_ROW_KEY_COLUMN).split(",")
 
   logger.info(s"Fields Initiated --> ${this.getClass.getFields.map(f => s"${f.getName} --> ${f.get().toString}").mkString("\n")}")
   logger.info(s"Completed Building --> ${this.getClass.getName}")

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseConfigs.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseConfigs.scala
@@ -32,8 +32,10 @@ object HbaseConfigs {
   val hbaseFilter: String = "gimel.hbase.get.filter"
   val hbaseRowKey: String = "gimel.hbase.rowkey"
   val hbaseColumnNamewithColumnFamilyAppended: String = "gimel.hbase.colName.with.cfName.appended"
-  val hbaseUseColumnsSpecifiedFlag: String = "gimel.hbase.columns.specified.flag"
   val hbaseSiteXMLHDFSPathKey: String = "gimel.hbase.site.xml.hdfs.path"
+  val hbaseMaxRecordsForSchema: String = "gimel.hbase.schema.max.records"
+  val hbaseMaxColumnsForSchema: String = "gimel.hbase.schema.max.columns"
+
 }
 
 

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseConstants.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/conf/HbaseConstants.scala
@@ -21,12 +21,15 @@ package com.paypal.gimel.hbase.conf
 
 object HbaseConstants {
   // basic variable references
-  val defaultRowKeyColumn = "rowKey"
-  val hbaseDefaultNamespace = "default"
+  val DEFAULT_ROW_KEY_COLUMN = "rowKey"
+  val DEFAULT_NAMESPACE = "default"
 
-  val scanOperation = "scan"
-  val getOperation = "get"
-  val putOperation = "put"
+  val SCAN_OPERATION = "scan"
+  val GET_OPERATION = "get"
+  val PUT_OPERATION = "put"
 
   val NONE_STRING = "NONE"
+
+  val MAX_SAMPLE_RECORDS_FOR_SCHEMA = "1000"
+  val MAX_COLUMNS_FOR_SCHEMA = "100000"
 }

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBaseLookUp.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBaseLookUp.scala
@@ -45,7 +45,7 @@ class HBaseLookUp(sparkSession: SparkSession) {
   /**
     * This function reads all or given columns in column family for a rowKey specified by user
     *
-    * @param Dataset Name
+    * @param dataset Name
     * @param dataSetProps
     *                props is the way to set various additional parameters for read and write operations in DataSet class
     *                Example Usecase : Hbase lookup for rowKey=r1 and columns c1, c12 of column family cf1 and c2 of cf2

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBasePut.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBasePut.scala
@@ -40,7 +40,7 @@ class HBasePut(sparkSession: SparkSession) {
   /**
     * This function performs put(insert/update) operation on each row of dataframe
     *
-    * @param Dataset Name
+    * @param dataset Name
     * @param dataFrame The Dataframe to write into Target
     * @param dataSetProps
     *                  props is the way to set various additional parameters for read and write operations in DataSet class
@@ -54,7 +54,11 @@ class HBasePut(sparkSession: SparkSession) {
       // Hbase configuration
       val conf = new HbaseClientConfiguration(dataSetProps)
       // Getting (Column family -> Array[Columns]) mapping
-      val columnFamilyToColumnMapping: Map[String, Array[String]] = hbaseUtilities.getColumnMappingForColumnFamily(conf.hbaseTableColumnMapping)
+      val columnFamilyToColumnMapping: Map[String, Array[String]] = hbaseUtilities.getColumnMappingForColumnFamily(conf.hbaseNameSpace,
+        conf.hbaseTableName,
+        conf.hbaseTableColumnMapping,
+        conf.maxSampleRecordsForSchema,
+        conf.maxColumnsForSchema)
       logger.info("Column mapping -> " + columnFamilyToColumnMapping)
       // Converting columnFamilyToColumnMapping to a map of (Column -> Column Family)
       val columnToColumnFamilyMapping = columnFamilyToColumnMapping.flatMap(cfCols => cfCols._2.map(col => (col, cfCols._1)))

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBaseScanner.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/main/scala/com/paypal/gimel/hbase/utilities/HBaseScanner.scala
@@ -19,13 +19,14 @@
 
 package com.paypal.gimel.hbase.utilities
 
-import scala.collection.JavaConverters._
-
+import org.apache.commons.lang.StringEscapeUtils
 import org.apache.hadoop.hbase.{CellUtil, HBaseConfiguration, TableName}
 import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory, Scan}
 import org.apache.hadoop.hbase.filter.PageFilter
 import org.apache.hadoop.hbase.util.Bytes
+import scala.collection.JavaConverters._
 
+import com.paypal.gimel.common.utilities.GenericUtils
 import com.paypal.gimel.logger.Logger
 
 object HBaseScanner {
@@ -41,7 +42,10 @@ class HBaseScanner() {
   /**
     * Returns schema of hbase table
     *
-    * @param tableName : Name of hbase table
+    * @param connection
+    * @param namespace
+    * @param tableName
+    * @param maxResults : Number of maximum records to be scanned
     * @return Map of [Column Family -> Array[Columns] ]
     */
   def getSchema(connection: Connection, namespace: String, tableName: String, rowKey: String, maxResults: Int): Map[String, Array[String]] = {
@@ -49,13 +53,16 @@ class HBaseScanner() {
     val tbl = connection.getTable(table)
     // INITIATE SCANNER
     val scan = new Scan()
-    val fil = new PageFilter(maxResults)
-    scan.setFilter(fil)
-    val scanner = tbl.getScanner(scan)
 
-    val rs = tbl.getScanner(scan)
+    // Setting the Page Filter to retrieve pageSize records from each region server
+    val pageSize = getPageSize(connection, table, maxResults)
+    logger.info("Setting the pageSize = " + pageSize)
+    val filter = new PageFilter(maxResults)
+    scan.setFilter(filter)
+
     var count = 0
-    try {
+    // Iterate through all the records retrieved from HBase and get column family and column names
+    GenericUtils.withResources(tbl.getScanner(scan)) { scanner =>
       val res = scanner.iterator().asScala.flatMap { result =>
         count = count + 1
         val cells = result.listCells().iterator().asScala
@@ -64,24 +71,143 @@ class HBaseScanner() {
       logger.info(s"Records Count for ${tableName} : " + count)
       val rowKeyMap = Map("rowKey" -> Array(rowKey))
       rowKeyMap ++ res
-    } finally {
-      rs.close()
     }
   }
 
   /**
-    * Returns schema of hbase table
+    * Returns schema of hbase table with specified maximum number of columns and result size
     *
-    * @param tableName : Name of hbase table
+    * @param connection
+    * @param namespace
+    * @param tableName
+    * @param maxResults : Number of maximum records to be scanned
+    * @param maxColumns : Number of maximum columns to be scanned
+    * @param maxResultSize : Maximum result size in bytes
     * @return Map of [Column Family -> Array[Columns] ]
     */
-  def getSchema(namespace: String, tableName: String, rowKey: String, maxResults: Int): Map[String, Array[String]] = {
+  def getSchema(connection: Connection, namespace: String, tableName: String, maxResults: Int, maxColumns: Int, maxResultSize : Long): Map[String, Array[String]] = {
+    val table: TableName = TableName.valueOf(namespace + ":" + tableName)
+    val tbl = connection.getTable(table)
+    // INITIATE SCANNER
+    val scan = new Scan()
+
+    // Setting the Page Filter to retrieve pageSize records from each region server
+    val pageSize = getPageSize(connection, table, maxResults)
+    logger.info("Setting the pageSize = " + pageSize)
+    val fil = new PageFilter(maxResults)
+    scan.setFilter(fil)
+    // Setting the maximum result size in bytes
+    scan.setMaxResultSize(maxResultSize)
+
+    var count = 0
+    var columnsCount = 0
+    // Iterate through all the records retrieved from HBase and get column family and column names
+    GenericUtils.withResources(tbl.getScanner(scan)) { scanner =>
+      val res = scanner.iterator().asScala.takeWhile(_ => columnsCount < maxColumns).flatMap { result =>
+        count = count + 1
+        val cells = result.listCells()
+        columnsCount = cells.size()
+        val cellsItr = cells.iterator().asScala
+        // Escape each column family and column in case of any special characters
+        cellsItr.map(cell => (StringEscapeUtils.escapeJava(Bytes.toString(CellUtil.cloneFamily(cell))),
+          StringEscapeUtils.escapeJava(Bytes.toString(CellUtil.cloneQualifier(cell))))).toList
+      }.toList.distinct.groupBy(_._1).map(x => (x._1, x._2.map(p => p._2).toArray))
+      logger.info(s"Records Count for ${tableName} : " + count)
+      res
+    }
+  }
+
+  /**
+    * Returns schema of hbase table with specified maximum number of columns
+    *
+    * @param connection
+    * @param namespace
+    * @param tableName
+    * @param maxResults : Number of maximum records to be scanned
+    * @param maxColumns : Number of maximum columns to be scanned
+    * @return Map of [Column Family -> Array[Columns] ]
+    */
+  def getSchema(connection: Connection, namespace: String, tableName: String, maxResults: Int, maxColumns: Int): Map[String, Array[String]] = {
+    val table: TableName = TableName.valueOf(namespace + ":" + tableName)
+    val tbl = connection.getTable(table)
+    // INITIATE SCANNER
+    val scan = new Scan()
+
+    // Setting the Page Filter to retrieve pageSize records from each region server
+    val pageSize = getPageSize(connection, table, maxResults)
+    logger.info("Setting the pageSize = " + pageSize)
+    val filter = new PageFilter(pageSize)
+    scan.setFilter(filter)
+
+    var count = 0
+    var columnsCount = 0
+    // Iterate through all the records retrieved from HBase and get column family and column names
+    GenericUtils.withResources(tbl.getScanner(scan)) { scanner =>
+      val res = scanner.iterator().asScala.takeWhile(_ => columnsCount < maxColumns).flatMap { result =>
+        count = count + 1
+        val cells = result.listCells()
+        columnsCount = cells.size()
+        val cellsItr = cells.iterator().asScala
+        // Escape each column family and column in case of any special characters
+        cellsItr.map(cell => (StringEscapeUtils.escapeJava(Bytes.toString(CellUtil.cloneFamily(cell))),
+          StringEscapeUtils.escapeJava(Bytes.toString(CellUtil.cloneQualifier(cell))))).toList
+      }.toList.distinct.groupBy(_._1).map(x => (x._1, x._2.map(p => p._2).toArray))
+      logger.info(s"Records Count for ${tableName} : " + count)
+      res
+    }
+  }
+
+  /**
+    * Returns page size based on the number of regions and maxResults size
+    *
+    * @param connection
+    * @param table
+    * @param maxResults : Number of maximum records to be scanned
+    * @return Page Size
+    */
+  def getPageSize(connection: Connection, table: TableName, maxResults: Int): Int = {
+    // Getting total region servers to decide the PageFilter size
+    val regionLocator = connection.getRegionLocator(table)
+    val numRegionServers = regionLocator.getAllRegionLocations().asScala.map(eachRegion => eachRegion.getHostname()).distinct.size
+    if (numRegionServers == 0) {
+      0
+    } else {
+      Math.max(maxResults / numRegionServers, 1)
+    }
+  }
+
+  /**
+    * Returns schema of hbase table by creating a connection
+    *
+    * @param namespace : Name of hbase name space
+    * @param tableName : Name of hbase table
+    * @param maxResults : Number of maximum records to be scanned
+    * @param maxColumns : Number of maximum columns to be scanned
+    * @return Map of [Column Family -> Array[Columns] ]
+    */
+  def getSchema(namespace: String, tableName: String, maxResults: Int, maxColumns: Int): Map[String, Array[String]] = {
     val conf = HBaseConfiguration.create()
-    val connection = ConnectionFactory.createConnection(conf)
-    try {
-      getSchema(connection, namespace, tableName, rowKey, maxResults)
-    } finally {
-      connection.close()
+    GenericUtils.withResources(ConnectionFactory.createConnection(conf)) {
+      connection =>
+        getSchema(connection, namespace, tableName, maxResults, maxColumns)
+    }
+  }
+
+  /**
+    * Returns schema of hbase table by creating a connection with specified maximum number of columns
+    *
+    * @param namespace
+    * @param tableName
+    * @param maxResults : Number of maximum records to be scanned
+    * @param maxColumns : Number of maximum columns to be scanned
+    * @param maxResultSize : Maximum result size in bytes
+    * @return Map of [Column Family -> Array[Columns] ]
+    */
+  def getSchema(namespace: String, tableName: String, maxResults: Int, maxColumns: Int, maxResultSize : Long): Map[String, Array[String]] = {
+    val conf = HBaseConfiguration.create()
+    GenericUtils.withResources(ConnectionFactory.createConnection(conf)) {
+      connection =>
+        getSchema(connection, namespace, tableName, maxResults, maxColumns, maxResultSize)
     }
   }
 }

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/DataSetTest.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/DataSetTest.scala
@@ -53,46 +53,6 @@ class DataSetTest extends HBaseLocalClient with Matchers {
     assert(df.count() == 10)
   }
 
-  test("Read operation - missing " + HbaseConfigs.hbaseColumnMappingKey) {
-    val props : Map[String, String] = Map(HbaseConfigs.hbaseNamespaceKey -> "default",
-      HbaseConfigs.hbaseTableKey -> s"""$tableName""",
-      HbaseConfigs.hbaseRowKey -> "id")
-    val dataSetName = "HBase.Local.default." + tableName
-    val dataSetProperties = DataSetProperties(dataSetName, null, null, props)
-    val datasetProps : Map[String, Any] = Map("dataSetProperties" -> dataSetProperties)
-    val exception = intercept[Exception] {
-      dataSet.read(dataSetName, datasetProps)
-    }
-    assert(exception.getMessage.contains("HBase column family to columns mapping not found.") == true)
-  }
-
-  test("Read operation - missing " + HbaseConfigs.hbaseTableKey) {
-    val props : Map[String, String] = Map(HbaseConfigs.hbaseNamespaceKey -> "default",
-      HbaseConfigs.hbaseRowKey -> "id",
-      HbaseConfigs.hbaseColumnMappingKey -> "personal:name,personal:address,personal:age,professional:company,professional:designation,professional:salary")
-    val dataSetName = "HBase.Local.default." + tableName
-    val dataSetProperties = DataSetProperties(dataSetName, null, null, props)
-    val datasetProps : Map[String, Any] = Map("dataSetProperties" -> dataSetProperties)
-    val exception = intercept[Exception] {
-      dataSet.read(dataSetName, datasetProps)
-    }
-    assert(exception.getMessage.contains("HBase table name not found.") == true)
-  }
-
-  test("Read operation - incorrect " + HbaseConfigs.hbaseColumnMappingKey) {
-    val props : Map[String, String] = Map(HbaseConfigs.hbaseNamespaceKey -> "default",
-      HbaseConfigs.hbaseTableKey -> s"""$tableName""",
-      HbaseConfigs.hbaseRowKey -> "id",
-      HbaseConfigs.hbaseColumnMappingKey -> ":key,personal:name,personal:address,personal:age,professional:company,professional:")
-    val dataSetName = "HBase.Local.default." + tableName
-    val dataSetProperties = DataSetProperties(dataSetName, null, null, props)
-    val datasetProps : Map[String, Any] = Map("dataSetProperties" -> dataSetProperties)
-    val exception = intercept[Exception] {
-      dataSet.read(dataSetName, datasetProps)
-    }
-    assert(exception.getMessage.contains("Column family to column mapping pattern is not correct") == true)
-  }
-
   test("Write operation - column given in input via " + HbaseConfigs.hbaseColumnMappingKey + " not present in dataframe to write") {
     val props : Map[String, String] = Map(HbaseConfigs.hbaseNamespaceKey -> "default",
       HbaseConfigs.hbaseTableKey -> s"""$tableName""",

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/utilities/HBaseScannerTest.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/utilities/HBaseScannerTest.scala
@@ -24,21 +24,22 @@ import org.scalatest.{BeforeAndAfterAll, Matchers}
 import com.paypal.gimel.common.catalog.DataSetProperties
 import com.paypal.gimel.hbase.conf.HbaseConfigs
 
-class HBaseLookUpTest extends HBaseLocalClient with Matchers with BeforeAndAfterAll {
-  ignore ("get") {
+class HBaseScannerTest extends HBaseLocalClient with Matchers with BeforeAndAfterAll {
+  ignore("getSchema") {
     val props : Map[String, String] = Map(HbaseConfigs.hbaseNamespaceKey -> "default",
       HbaseConfigs.hbaseTableKey -> s"""$tableName""",
       HbaseConfigs.hbaseRowKey -> "id",
-      HbaseConfigs.hbaseFilter -> "rowKey=10",
-      HbaseConfigs.hbaseColumnMappingKey -> "personal:name,personal:address,personal:age,professional:company,professional:designation,professional:salary",
-      HbaseConfigs.hbaseOperation -> "get")
+      HbaseConfigs.hbaseColumnMappingKey -> "personal:name,personal:address,personal:age,professional:company,professional:designation,professional:salary")
     val dataSetName = "HBase.Local.default." + tableName
     val dataSetProperties = DataSetProperties(dataSetName, null, null, props)
     val datasetProps : Map[String, Any] = Map("dataSetProperties" -> dataSetProperties)
-    val dataFrame = mockDataInDataFrame(10)
+    val dataFrame = mockDataInDataFrame(1000)
     dataFrame.show(1)
-    val df = HBasePut(sparkSession).put(dataSetName, dataFrame, datasetProps)
-    val dfLookUp = HBaseLookUp(sparkSession).get(dataSetName, datasetProps)
-    dfLookUp.show
+    HBaseSparkConnector(sparkSession).write(dataSetName, dataFrame, datasetProps)
+    val schema = HBaseScanner().getSchema("default", tableName, 100, 100000)
+    println(schema)
+    assert(schema.keys.sameElements(cfs))
+    assert(schema("personal").sameElements(Array("name", "age", "address")))
+    assert(schema("professional").sameElements(Array("company", "designation", "salary")))
   }
 }

--- a/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/utilities/HBaseUtilitiesTest.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-hbase-1.2/src/test/scala/com/paypal/gimel/hbase/utilities/HBaseUtilitiesTest.scala
@@ -48,19 +48,5 @@ class HBaseUtilitiesTest extends HBaseLocalClient with Matchers with BeforeAndAf
     val mapping2 = hbaseUtilities.getColumnMappingForColumnFamily("cf1:c1,:key,cf1:c2,cf1:c3,cf2:c4")
     assert(mapping2("cf1").sameElements(Array("c1", "c2", "c3")))
     assert(mapping2("cf2").sameElements(Array("c4")))
-
-    // it should throw exception with incorrect or empty pattern
-    assert(checkForIncorrectPattern("") == true)
-    assert(checkForIncorrectPattern(":key") == true)
-    assert(checkForIncorrectPattern("cf1:c1,cf1:") == true)
-    assert(checkForIncorrectPattern("cf1,cf1") == true)
-  }
-
-  def checkForIncorrectPattern(pattern: String): Boolean = {
-    println("Checking for pattern -> " + pattern)
-    val exception = intercept[Exception] {
-      hbaseUtilities.getColumnMappingForColumnFamily(pattern)
-    }
-    exception.getMessage.contains("Column family to column mapping pattern is not correct")
   }
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #182 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
- Get schema for hbase table automatically.
- Today the connector for HBase - open source SHC connector, requires schema to read/write. It fails if it doesnt find this property gimel.hbase.column.mapping. This feature will automatically get the schema and hence set this property.

### How was this change validated?
Spark shell

### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

