### PR TITLE
[#213] Cache DataSetProperties for each Data API call

### DIFF
--- a/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/catalog/CatalogProvider.scala
+++ b/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/catalog/CatalogProvider.scala
@@ -159,14 +159,6 @@ object CatalogProvider {
     }
   }
 
-  /*
-   * Clear cached DataSetProperties Map
-   */
-  def clearDataSetPropertyCache(): Unit = {
-    logger.info("Clearing DataSetProperties cache.")
-    cachedDataSetPropsMap.clear()
-  }
-
   /**
     * Creates DataSetProperties provided by user and Returns to caller
     *

--- a/gimel-dataapi/gimel-common/src/test/scala/com/paypal/gimel/common/utilities/catalog/CatalogProviderTest.scala
+++ b/gimel-dataapi/gimel-common/src/test/scala/com/paypal/gimel/common/utilities/catalog/CatalogProviderTest.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 PayPal Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.paypal.gimel.common.utilities.catalog
+
+import org.scalatest._
+
+import com.paypal.gimel.common.catalog.CatalogProvider
+
+class CatalogProviderTest extends FunSpec with Matchers {
+
+  describe("getDataSetProperties") {
+    it ("should return the DataSetProperties object for a given dataset") {
+      val dataSetProperties_json = """{
+          "datasetType": "KAFKA",
+          "fields": [],
+          "partitionFields": [],
+          "props": {
+              "gimel.storage.type":"KAFKA",
+              "bootstrap.servers":"kafka:9092",
+              "gimel.kafka.whitelist.topics":"gimel.test.json",
+              "zookeeper.connection.timeout.ms":"10000",
+              "gimel.kafka.checkpoint.zookeeper.host":"zookeeper:2181",
+              "gimel.kafka.checkpoint.zookeeper.path":"/pcatalog/kafka_consumer/checkpoint",
+              "auto.offset.reset":"earliest",
+              "datasetName":"udc.kafka_test_json",
+              "gimel.deserializer.class":"com.paypal.gimel.deserializers.generic.JsonDynamicDeserializer",
+              "gimel.serializer.class":"com.paypal.gimel.serializers.generic.JsonSerializer"
+          }
+      }"""
+      val options = Map("udc.kafka_test_json.dataSetProperties" -> dataSetProperties_json,
+        "gimel.kafka.throttle.batch.fetchRowsOnFirstRun" -> 1000,
+        "gimel.kafka.throttle.batch.parallelsPerPartition" -> 250,
+        "gimel.catalog.provider"->"USER")
+      CatalogProvider.getDataSetProperties("udc.kafka_test_json", options).getClass.getTypeName
+        .shouldBe("com.paypal.gimel.common.catalog.DataSetProperties")
+    }
+
+    it ("should return the DataSetProperties for a given dataset from cache table if it exists") {
+      val dataSetProperties_json = """{
+          "datasetType": "KAFKA",
+          "fields": [],
+          "partitionFields": [],
+          "props": {
+              "gimel.storage.type":"KAFKA",
+              "bootstrap.servers":"kafka:9092",
+              "gimel.kafka.whitelist.topics":"gimel.test.json1",
+              "zookeeper.connection.timeout.ms":"10000",
+              "gimel.kafka.checkpoint.zookeeper.host":"zookeeper:2181",
+              "gimel.kafka.checkpoint.zookeeper.path":"/pcatalog/kafka_consumer/checkpoint",
+              "auto.offset.reset":"earliest",
+              "datasetName":"udc.kafka_test_json1",
+              "gimel.deserializer.class":"com.paypal.gimel.deserializers.generic.JsonDynamicDeserializer",
+              "gimel.serializer.class":"com.paypal.gimel.serializers.generic.JsonSerializer"
+          }
+      }"""
+      val options = Map("udc.kafka_test_json1.dataSetProperties" -> dataSetProperties_json,
+        "gimel.kafka.throttle.batch.fetchRowsOnFirstRun" -> 1000,
+        "gimel.kafka.throttle.batch.parallelsPerPartition" -> 250,
+        "gimel.catalog.provider" -> "USER")
+      CatalogProvider.getDataSetProperties("udc.kafka_test_json1", options).getClass.getTypeName
+        .shouldBe("com.paypal.gimel.common.catalog.DataSetProperties")
+
+      // Cache table should contain the dataset names for which we have already made a call
+      CatalogProvider.cachedDataSetPropsMap.keys.sameElements(Set("udc.kafka_test_json", "udc.kafka_test_json1"))
+      // Second call to getDataSetProperties should return object from cache
+      CatalogProvider.getDataSetProperties("udc.kafka_test_json1", options).getClass.getTypeName
+        .shouldBe("com.paypal.gimel.common.catalog.DataSetProperties")
+    }
+  }
+}

--- a/gimel-dataapi/gimel-core/src/main/scala/com/paypal/gimel/DataSet.scala
+++ b/gimel-dataapi/gimel-core/src/main/scala/com/paypal/gimel/DataSet.scala
@@ -200,9 +200,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.toString + "\n" + msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 
@@ -333,9 +330,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.toString + "\n" + msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }
@@ -448,9 +442,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }
@@ -635,9 +626,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 
@@ -765,9 +753,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 
@@ -894,9 +879,6 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
-    } finally {
-      // Clearing the DataSetProperties cache as next call may be with different properties
-      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }

--- a/gimel-dataapi/gimel-core/src/main/scala/com/paypal/gimel/DataSet.scala
+++ b/gimel-dataapi/gimel-core/src/main/scala/com/paypal/gimel/DataSet.scala
@@ -200,6 +200,9 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.toString + "\n" + msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 
@@ -330,6 +333,9 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.toString + "\n" + msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }
@@ -442,6 +448,9 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }
@@ -626,8 +635,10 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
-
   }
 
   /**
@@ -720,6 +731,7 @@ class DataSet(val sparkSession: SparkSession) {
       )
     }
     catch {
+
       case e: Throwable =>
 
         logger.error(s"Error Description\n dataset=${dataSet}\n method=${MethodName}\n Error: ${e.printStackTrace()}")
@@ -753,8 +765,10 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
-
   }
 
   /**
@@ -845,6 +859,7 @@ class DataSet(val sparkSession: SparkSession) {
       )
     }
     catch {
+
       case e: Throwable =>
 
         logger.error(s"Error Description\n dataset=${dataSet}\n method=${MethodName}\n Error: ${e.printStackTrace()}")
@@ -879,6 +894,9 @@ class DataSet(val sparkSession: SparkSession) {
 
         val msg = s"Error in DataSet ${MethodName} Operation. Common Gimel 'Exceptions' are explained here : http://go/gimel/exceptions"
         throw new DataSetOperationException(e.getMessage + "\n" + msg, e)
+    } finally {
+      // Clearing the DataSetProperties cache as next call may be with different properties
+      CatalogProvider.clearDataSetPropertyCache()
     }
 
   }

--- a/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryProcessor.scala
+++ b/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryProcessor.scala
@@ -250,6 +250,7 @@ object GimelQueryProcessor {
     } finally {
       logger.info("Unsetting the property -> " + GimelConstants.HBASE_PAGE_SIZE)
       sparkSession.conf.unset(GimelConstants.HBASE_PAGE_SIZE)
+      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 

--- a/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryProcessor.scala
+++ b/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryProcessor.scala
@@ -250,7 +250,6 @@ object GimelQueryProcessor {
     } finally {
       logger.info("Unsetting the property -> " + GimelConstants.HBASE_PAGE_SIZE)
       sparkSession.conf.unset(GimelConstants.HBASE_PAGE_SIZE)
-      CatalogProvider.clearDataSetPropertyCache()
     }
   }
 

--- a/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryUtils.scala
+++ b/gimel-dataapi/gimel-sql/src/main/scala/com/paypal/gimel/sql/GimelQueryUtils.scala
@@ -714,7 +714,7 @@ object GimelQueryUtils {
           case true =>
           case _ =>
         }
-        val dataSetProperties: DataSetProperties = CatalogProvider.getDataSetProperties(dest.get)
+        val dataSetProperties: DataSetProperties = CatalogProvider.getDataSetProperties(dest.get, options)
         //        val dataSetProperties = GimelServiceUtilities().getDataSetProperties(dest.get)
         dataSetProperties.datasetType.toString match {
           case "HIVE" | "NONE" =>


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #213 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [ ] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
Currently, for every getDataSetProperties call, a new DataSetProperties object is created which involves calling to UDC Rest API multiple times. In order to avoid this cache the already computed dataset props.

Cache is cleared after each gsql query or data api call as the next one may occur with different properties.

### How was this change validated?
Spark shell
Unit tests

### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

