### PR TITLE
[#225] Set jdbc user based on gts user in GSQL

### DIFF
--- a/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/conf/GimelConstants.scala
+++ b/gimel-dataapi/gimel-common/src/main/scala/com/paypal/gimel/common/conf/GimelConstants.scala
@@ -230,6 +230,7 @@ object GimelConstants {
   // GTS
   val GTS_DEFAULT_USER = ""
   val GTS_USER_CONFIG = "gimel.gts.user"
+  val GTS_DEFAULT_USER_FLAG = "spark.gimel.gts.default.user"
   val GTS_IMPERSONATION_FLAG = "spark.gimel.gts.impersonation.enabled"
 
   // Serialization/Deserialization Class

--- a/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCAuthUtilities.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCAuthUtilities.scala
@@ -148,7 +148,8 @@ class JDBCAuthUtilities(sparkSession: SparkSession) extends Serializable {
         // Loading the custom auth provider at runtime
         val authLoaderClassName = GenericUtils.getValueAny(dataSetProps, JdbcConfigs.jdbcAuthLoaderClass, "")
         if (authLoaderClassName.isEmpty) {
-          throw new IllegalArgumentException(s"You need to set the property ${JdbcConfigs.jdbcAuthLoaderClass} with ${JdbcConfigs.jdbcPasswordStrategy} = ${JdbcConstants.JDBC_CUSTOM_PASSWORD_STRATEGY}")
+          throw new IllegalArgumentException(s"You need to set the property ${JdbcConfigs.jdbcAuthLoaderClass} " +
+            s"with ${JdbcConfigs.jdbcPasswordStrategy} = ${JdbcConstants.JDBC_CUSTOM_PASSWORD_STRATEGY}")
         }
         val authLoader = Class.forName(authLoaderClassName).newInstance.asInstanceOf[com.paypal.gimel.common.security.AuthProvider]
         password = authLoader.getCredentials(dataSetProps ++ Map(GimelConstants.GIMEL_AUTH_REQUEST_TYPE -> JdbcConstants.JDBC_AUTH_REQUEST_TYPE))

--- a/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCConnectionUtility.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCConnectionUtility.scala
@@ -72,9 +72,11 @@ class JDBCConnectionUtility(sparkSession: SparkSession,
 
   val jdbcPasswordStrategy: String = JDBCConnectionUtility.getJdbcPasswordStrategy(dataSetProps)
 
+  val gts_default_user = sparkSession.conf.get(GimelConstants.GTS_DEFAULT_USER_FLAG, "")
+
   // get actual JDBC user
   // Negating with file strategy, as in many places other than "file" default case is handled!
-  var jdbcUser: String = if (sparkSession.sparkContext.sparkUser.equalsIgnoreCase(GimelConstants.GTS_DEFAULT_USER)
+  var jdbcUser: String = if (sparkSession.sparkContext.sparkUser.equalsIgnoreCase(gts_default_user)
     && !JdbcConstants.JDBC_FILE_PASSWORD_STRATEGY.equals(jdbcPasswordStrategy)) {
     // Validate incoming user to be able to set query band
     val gtsUser: String = sparkSession.sparkContext.getLocalProperty(GimelConstants.GTS_USER_CONFIG)
@@ -153,7 +155,7 @@ class JDBCConnectionUtility(sparkSession: SparkSession,
         if (jdbcPasswordStrategy.equalsIgnoreCase(JdbcConstants.JDBC_DEFAULT_PASSWORD_STRATEGY)) {
           // check For GTS queries
           // If sparkUser = livy AND GTS user != jdbcUser, then throw exception.
-          if (sparkUser.equalsIgnoreCase(GimelConstants.GTS_DEFAULT_USER)) {
+          if (sparkUser.equalsIgnoreCase(gts_default_user)) {
             // GTS Block
             val gtsUser: String = sparkSession.sparkContext.getLocalProperty(GimelConstants.GTS_USER_CONFIG)
             if (!user.equalsIgnoreCase(gtsUser)) {

--- a/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCUtilities.scala
+++ b/gimel-dataapi/gimel-connectors/gimel-jdbc/src/main/scala/com/paypal/gimel/jdbc/utilities/JDBCUtilities.scala
@@ -95,13 +95,11 @@ class JDBCUtilities(sparkSession: SparkSession) extends Serializable {
     // logger.setLogLevel("CONSOLE")
     // sparkSession.conf.set("gimel.logging.level", "CONSOLE")
 
-    val jdbcConnectionUtility: JDBCConnectionUtility = JDBCConnectionUtility(sparkSession, dataSetProps)
-
     val jdbcOptions: Map[String, String] = JdbcAuxiliaryUtilities.getJDBCOptions(dataSetProps)
-    logger.info(s"Received JDBC options: $jdbcOptions and dataset options: $dataSetProps")
-
     val jdbcURL = jdbcOptions(JdbcConfigs.jdbcUrl)
     val dbtable = jdbcOptions(JdbcConfigs.jdbcDbTable)
+    val jdbcConnectionUtility: JDBCConnectionUtility = JDBCConnectionUtility(sparkSession, dataSetProps ++ jdbcOptions)
+    logger.info(s"Received JDBC options: $jdbcOptions and dataset options: $dataSetProps")
 
     // get connection
     val conn: Connection = getOrCreateConnection(jdbcConnectionUtility)
@@ -198,7 +196,7 @@ class JDBCUtilities(sparkSession: SparkSession) extends Serializable {
       if (mergedJdbcOptions.nonEmpty) {
         mergedJdbcOptions
       } else {
-        dataSetProps
+        dataSetProps ++ jdbcConnectionOptions
       }
     )
     val jdbc_url = mergedJdbcOptions(JdbcConfigs.jdbcUrl)

--- a/gimel-dataapi/gimel-examples/src/main/scala/com/paypal/gimel/examples/APIUsageAcrossDataSets.scala
+++ b/gimel-dataapi/gimel-examples/src/main/scala/com/paypal/gimel/examples/APIUsageAcrossDataSets.scala
@@ -22,7 +22,7 @@ package com.paypal.gimel.examples
 import org.apache.spark.sql._
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 
-import com.paypal.gimel.{DataSet, DataSetType}
+import com.paypal.gimel.{DataSet}
 import com.paypal.gimel.logger.Logger
 
 object APIUsageAcrossDataSets {
@@ -53,7 +53,7 @@ object APIUsageAcrossDataSets {
     */
 
   // Initiate Pcatalog DataSet
-  val systemType = DataSetType
+  // val systemType = DataSetType
   val dataSet: DataSet = DataSet(sparkSession)
 
   /**

--- a/gimel-dataapi/gimel-examples/src/main/scala/com/paypal/gimel/examples/APIUsageKafkaProduceConsume.scala
+++ b/gimel-dataapi/gimel-examples/src/main/scala/com/paypal/gimel/examples/APIUsageKafkaProduceConsume.scala
@@ -112,7 +112,7 @@ object APIUsageKafkaProduceConsume extends App {
   val df: DataFrame = sqlContext.read.json(rdd)
 
   // Get a List of Supported Systems for DataSet Operations
-  val systemType = DataSetType
+  // val systemType = DataSetType
 
   // DataSet Write API Call
   dataSet.write(datasetName, df)


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #225 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [x] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
As GTS starts a spark session with a default username and allow other users to query with their own usernames, we need to check actual spark user in the code for authentication and logging purposes.
Thats why, we set the JDBC user to actual spark user to set the query band for authentication.

In this PR, the gts default user is made configurable by passing the username to spark.gimel.gts.default.user conf in the startup script.

### How was this change validated?


### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

