### PR TITLE
[#224] Add mvn profile for hwx-2.6.5.0-292

### DIFF
--- a/docs/getting-started/build-gimel.md
+++ b/docs/getting-started/build-gimel.md
@@ -39,7 +39,8 @@ Run below command to build
 | -------- | -------- | -------- |
 | Default | ```build/gimel install -T 8 -B``` | Recommended. Builds with all dependencies pulled from maven central - profile general |
 | General | ```build/gimel install -T 8 -B -Pgeneral``` | Builds with all dependencies pulled from maven central |
-| HWX releases | ```build/gimel clean install -T 8 -B -Phwx-2.6.3.11-1``` | Builds with all dependencies pulled from cluster1 works repo if available |
+| HWX release hwx-2.6.3.11-1 | ```build/gimel clean install -T 8 -B -Phwx-2.6.3.11-1``` | Builds with all dependencies pulled from horton works repo if available |
+| HWX release hwx-2.6.5.0-292 | ```build/gimel clean install -T 8 -B -Phwx-2.6.5.0-292``` | Builds with all dependencies pulled from horton works repo if available |
 | Stand Alone | ```build/gimel clean install -T 8 -B -Pstandalone``` | Builds gimel with scala packages bundled in jar, used for standalone execution of gimel jar / polling services |
 
 --------------------------------------------------------------------------------------------------------------------

--- a/gimel-dataapi/pom.xml
+++ b/gimel-dataapi/pom.xml
@@ -62,11 +62,7 @@ under the License.
         <cassandra.spark.version>2.0.6</cassandra.spark.version>
         <confluent.version>3.3.0</confluent.version>
         <elasticsearch.version>6.2.1</elasticsearch.version>
-        <gimel.version>2.0.0</gimel.version>
         <guava.version>16.0</guava.version>
-        <hadoop.version>2.7.3</hadoop.version>
-        <hbase.version>1.2.0</hbase.version>
-        <hive.version>1.2.1000.2.4.2.12-1</hive.version>
         <hortonworks.shc.version>1.1.2</hortonworks.shc.version>
         <http.client.version>4.5.3</http.client.version>
         <fasterxml.jackson.core.version>2.6.5</fasterxml.jackson.core.version>
@@ -76,19 +72,14 @@ under the License.
         <kafka.version>0.10.2.1</kafka.version>
         <kafka.binary.version>0-10</kafka.binary.version>
         <protobuf.javaformatter.version>1.4</protobuf.javaformatter.version>
-        <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11.8</scala.version>
         <gimel.logging.spark.binary.version>2.3</gimel.logging.spark.binary.version>
         <gimel.logging.version>0.4.3-SNAPSHOT</gimel.logging.version>
-        <scalatest.version>3.0.1</scalatest.version>
         <tranquility.version>0.8.2</tranquility.version>
         <mockito.version>2.13.0</mockito.version>
         <qubole.hive.jdbc.version>0.0.7</qubole.hive.jdbc.version>
-        <spark.binary.version>2.3</spark.binary.version>
-        <spark.version>2.3.0</spark.version>
         <spray.json.version>1.3.3</spray.json.version>
         <teradata.version>15.10.00.22</teradata.version>
-        <twitter.zookeeper.version>2.0.0_fs-b</twitter.zookeeper.version>
+        <curator.version>2.13.0</curator.version>
         <spark.kafka.connector.version>0-10_2.11</spark.kafka.connector.version>
         <spark.sftp.version>1.1.3</spark.sftp.version>
         <!-- These are added because of conflict in hbase-testing-utility-->

--- a/gimel-serde/pom.xml
+++ b/gimel-serde/pom.xml
@@ -34,49 +34,12 @@
 
     <properties>
         <confluent.version>3.3.0</confluent.version>
-        <java.version>1.8</java.version>
-        <scala.version>2.11.8</scala.version>
-        <spark.binary.version>2.3</spark.binary.version>
-        <spark.version>2.3.0</spark.version>
         <spray.json.version>1.3.3</spray.json.version>
-        <scala.binary.version>2.11</scala.binary.version>
-        <scalatest.version>3.0.1</scalatest.version>
-        <gimel.logging.spark.binary.version>2.3</gimel.logging.spark.binary.version>
-        <gimel.logging.version>0.4.3-SNAPSHOT</gimel.logging.version>
         <!-- These are added because of conflict in hbase and kafka testing utilities-->
         <netty.hadoop.version>3.9.9.Final</netty.hadoop.version>
         <netty.all.hadoop.version>4.1.17.Final</netty.all.hadoop.version>
-        <kafka.version>0.10.2.1</kafka.version>
+        <kafka.version>2.2.1</kafka.version>
     </properties>
-
-    <profiles>
-        <profile>
-            <id>general</id>
-            <activation>
-                <property>
-                    <name>general</name>
-                </property>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <packaging.scope>compile</packaging.scope>
-                <scala.packaging.scope>provided</scala.packaging.scope>
-                <spark.packaging.scope>compile</spark.packaging.scope>
-                <hive.packaging.scope>provided</hive.packaging.scope>
-                <hadoop.packaging.scope>provided</hadoop.packaging.scope>
-                <scala.version>2.11.8</scala.version>
-                <spark.binary.version>2.3</spark.binary.version>
-                <scaas.logger.spark.binary.version>2.3</scaas.logger.spark.binary.version>
-                <spark.version>2.3.0</spark.version>
-                <hadoop.version>2.7.3</hadoop.version>
-                <hive.version>1.2.1000</hive.version>
-                <hbase.version>1.1.2</hbase.version>
-                <zookeeper.version>3.4.6</zookeeper.version>
-                <hwx.version>hwx-2.6.5.0-292_s-${spark.binary.version}</hwx.version>
-                <packaging.tag/>
-            </properties>
-        </profile>
-    </profiles>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ under the License.
                 <hive.version>1.2.1000</hive.version>
                 <hbase.version>1.1.2</hbase.version>
                 <java.version>1.8</java.version>
+                <gimel.version>2.0.0</gimel.version>
                 <packaging.tag />
             </properties>
         </profile>
@@ -103,7 +104,6 @@ under the License.
                 <scala.binary.version>2.11</scala.binary.version>
                 <scala.version>2.11.8</scala.version>
                 <scalatest.version>3.0.1</scalatest.version>
-                <scalamock.version>4.1.0</scalamock.version>
                 <spark.binary.version>2.3</spark.binary.version>
                 <spark.version>2.3.0.2.6.3.11-1</spark.version>
                 <hadoop.version>2.7.3.2.6.3.11-1</hadoop.version>
@@ -131,6 +131,7 @@ under the License.
                 <scala.binary.version>2.11</scala.binary.version>
                 <scala.version>2.11.8</scala.version>
                 <scalatest.version>3.0.1</scalatest.version>
+                <scalatest.version>3.0.1</scalatest.version>
                 <scalamock.version>4.1.0</scalamock.version>
                 <spark.binary.version>2.3</spark.binary.version>
                 <spark.version>2.3.0.2.6.3.5-4</spark.version>
@@ -139,6 +140,35 @@ under the License.
                 <hbase.version>1.1.2.2.6.3.5-4</hbase.version>
                 <zookeeper.version>3.4.6.2.6.3.5-4</zookeeper.version>
                 <packaging.tag />
+            </properties>
+        </profile>
+        <profile>
+            <id>hwx-2.6.5.0-292</id>
+            <activation>
+                <property>
+                    <name>hortonworks-2.6.5.0-292_spark-2.3.0</name>
+                </property>
+            </activation>
+            <properties>
+                <packaging.scope>compile</packaging.scope>
+                <scala.packaging.scope>provided</scala.packaging.scope>
+                <spark.packaging.scope>compile</spark.packaging.scope>
+                <hive.packaging.scope>provided</hive.packaging.scope>
+                <hadoop.packaging.scope>provided</hadoop.packaging.scope>
+                <scala.version>2.11.8</scala.version>
+                <scala.binary.version>2.11</scala.binary.version>
+                <scalamock.version>4.1.0</scalamock.version>
+                <spark.binary.version>2.3</spark.binary.version>
+                <scaas.logger.spark.binary.version>2.3</scaas.logger.spark.binary.version>
+                <spark.version>2.3.0.2.6.5.0-292</spark.version>
+                <hadoop.version>2.7.3.2.6.5.0-292</hadoop.version>
+                <hive.version>1.2.1000.2.6.5.0-292</hive.version>
+                <hbase.version>1.1.2.2.6.5.0-292</hbase.version>
+                <zookeeper.version>3.4.13.2.6.5.0-292</zookeeper.version>
+                <hwx.version>hwx-2.6.5.0-292_s-${spark.binary.version}</hwx.version>
+                <gimel.version>2.0.0</gimel.version>
+                <scalatest.version>3.0.1</scalatest.version>
+                <packaging.tag/>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Make sure you have checked all steps below.

### GitHub Issue
Fixes #224 


### Checklist:
<!--- Go over all the following points. Check boxes that apply to this pull request -->
- [x] This pull request updates the documentation
- [ ] This pull request changes library dependencies
- [x] Title of the PR is of format (example) : [#25][Github] Add Pull Request Template

<!-- NOTE: lines that start with < - - ! and end with - - > are comments and will be ignored. -->
<!-- Please include the GitHub issue number in the PR title above. If an issue does not exist, please create one.-->
<!-- Example:[#25][Github] Add Pull Request Template where [#25 refers to https://github.com/paypal/gimel/issues/25] -->

### What is the purpose of this pull request?
Add separate profile for hwx-2.6.5.0-292 in the parent pom so that the jar can be built with hwx-2.6.5.0-292 binaries for spark, hadoop and other modules.

### How was this change validated?

Build command

```
mvn clean install -Phwx-2.6.5.0-292
```

### Commit Guidelines
- [x] My commits all reference GH issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

